### PR TITLE
chore(package): bump to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A complete routing library for React.js",
   "files": [
     "*.md",


### PR DESCRIPTION
Disabled manual propTypes validation so we're still able to use this old version of `react-router` with the latest breaking changes of React.